### PR TITLE
upgrade gcta from 1.26.0 to 1.92.2beta

### DIFF
--- a/docker/fastlmm-gcta.dockerfile
+++ b/docker/fastlmm-gcta.dockerfile
@@ -8,11 +8,23 @@ MAINTAINER Diana Cornejo  <dmc2245@cumc.columbia.edu>
 
 USER root
 		
-RUN conda install --yes -c bioconda -c biobuilds plink gcta==1.26.0
+RUN conda install --yes -c bioconda -c biobuilds plink
 
-RUN cd /tmp && curl -fsSL https://download.microsoft.com/download/B/0/9/B095C9A0-C08B-41F7-9C7E-76097E875235/FaSTLMM.207.zip -o FaSTLMM.zip && \
+RUN cd /tmp && \
+    curl -fsSL https://cnsgenomics.com/software/gcta/bin/gcta_1.93.2beta.zip -o gcta.zip && \
+    unzip gcta.zip && \
+    mv gcta_1.93.2beta/gcta64 /usr/local/bin && \
+    chmod a+x /usr/local/bin/gcta64 && \
+    cd - && \
+    rm -rf /tmp/*
+
+RUN cd /tmp && \
+    curl -fsSL https://download.microsoft.com/download/B/0/9/B095C9A0-C08B-41F7-9C7E-76097E875235/FaSTLMM.207.zip -o FaSTLMM.zip && \
     unzip FaSTLMM.zip && \
-    mv FaSTLMM.207c/Bin/Linux_MKL/fastlmmc  /usr/local/bin && chmod a+x /usr/local/bin/fastlmmc && cd - && rm -rf /tmp/*
+    mv FaSTLMM.207c/Bin/Linux_MKL/fastlmmc  /usr/local/bin && \
+    chmod a+x /usr/local/bin/fastlmmc && \
+    cd - && \
+    rm -rf /tmp/*
 
 RUN curl -fsSL http://statgen.us/files/2020/01/PRACDATA.zip -o PRACDATA.zip && \
     unzip PRACDATA.zip && \

--- a/docker/fastlmm-gcta.dockerfile
+++ b/docker/fastlmm-gcta.dockerfile
@@ -8,7 +8,7 @@ MAINTAINER Diana Cornejo  <dmc2245@cumc.columbia.edu>
 
 USER root
 		
-RUN conda install --yes -c bioconda -c biobuilds plink
+RUN conda install --yes -c bioconda plink
 
 RUN cd /tmp && \
     curl -fsSL https://cnsgenomics.com/software/gcta/bin/gcta_1.93.2beta.zip -o gcta.zip && \


### PR DESCRIPTION
The version available in biobuilds is the latest stable (1.26.0).  This is quite old and Dr. Cordell plans to work with some of the features in the newer beta builds.  As a result, we no longer install gcta using conda; instead we download the 64-bit linux build from cnsgenomics.com and install it into /usr/local/bin.